### PR TITLE
Missing comma in package.json

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,6 @@
   },
   "dependencies": {
     "crypto-js": "^3.1.0"
-  }
+  },
   "homepage": "https://github.com/ioberry/LoraWAN-Server"
 }


### PR DESCRIPTION
I was trying to browserify this package and ran into the error 
```
npm ERR! code EJSONPARSE
npm ERR! Failed to parse json
npm ERR! Unexpected token 'h' at 26:4
npm ERR!   "homepage": "https://github.com/ioberry/LoraWAN-Server"
npm ERR!    ^
npm ERR! File: /Users/z002qyr/workspace/iot-platform/k6/vendor/LoraWAN-Server/src/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/z002qyr/.npm/_logs/2020-02-17T20_36_29_713Z-debug.log
```

Looks like a comma was missing in the package.json